### PR TITLE
feat: add explicit tag to track name in Tracklist component

### DIFF
--- a/src/components/playlist/PlaylistBlock/Tracklist.tsx
+++ b/src/components/playlist/PlaylistBlock/Tracklist.tsx
@@ -40,9 +40,16 @@ export default function Tracklist({ playlist }: Props) {
               />
             </div>
             <div className="flex-1">
-              <p className="text-sm font-bold line-clamp-1">
-                {track.name}
-              </p>
+              <div className="flex items-center gap-1">
+                {track.explicit && (
+                  <div className="flex justify-center items-center text-center rounded font-medium text-primary text-xs min-h-4 min-w-4 bg-secondary ">
+                    E
+                  </div>
+                )}
+                <p className="text-sm font-bold line-clamp-1">
+                  {track.name}
+                </p>
+              </div>
               <div className="flex items-center line-clamp-1 gap-1">
                 {track.artists.map((artist) => {
                   return (


### PR DESCRIPTION
The changes in this commit modify the Tracklist component to display an "E" badge next to the track name if the track is marked as explicit. This provides visual indication to the user about the explicit content of the track.