### PR TITLE
feat: add token refreshing logic in getAccessToken function

### DIFF
--- a/src/lib/service/auth/index.ts
+++ b/src/lib/service/auth/index.ts
@@ -1,6 +1,7 @@
 import { validateRequest } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { sessionTable } from '@/lib/db/schema/user';
+import { env } from '@/lib/env/server';
 import { eq } from 'drizzle-orm';
 import { redirect } from 'next/navigation';
 
@@ -14,11 +15,45 @@ export async function getAccessToken() {
   const getAccessToken = await db
     .select({
       accessToken: sessionTable.accessToken,
+      refreshToken: sessionTable.refreshToken,
+      expiresAt: sessionTable.expiresAt,
     })
     .from(sessionTable)
     .where(eq(sessionTable.id, session.id));
 
-  const { accessToken } = getAccessToken[0];
+  const { accessToken, refreshToken, expiresAt } = getAccessToken[0];
+
+  if (new Date(expiresAt) < new Date()) {
+    console.log('Refreshing token');
+    const url = new URL('https://accounts.spotify.com/api/token');
+
+    const payload = {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        Authorization:
+          'Basic ' +
+          Buffer.from(
+            env.SPOTIFY_CLIENT_ID + ':' + env.SPOTIFY_CLIENT_SECRET,
+          ).toString('base64'),
+      },
+      body: 'grant_type=client_credentials',
+    };
+
+    const response = await fetch(url, payload);
+
+    const tokens = await response.json();
+
+    await db
+      .update(sessionTable)
+      .set({
+        accessToken: tokens.access_token,
+        expiresAt: expiresAt + tokens.expires_in,
+      })
+      .where(eq(sessionTable.id, session.id));
+
+    return tokens.access_token;
+  }
 
   return accessToken;
 }


### PR DESCRIPTION
The changes in this commit add logic to refresh the access token if it has expired. The function now checks the expiration time of the token and if it is expired, it makes a request to the Spotify API to get a new access token using the client credentials grant type. The new access token is then stored in the database and returned for further use. This ensures that the application always has a valid access token to make API requests to Spotify.