### PR TITLE
feat: update database driver to 'turso' and add support for authentication token in database credentials

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -4,8 +4,9 @@ import type { Config } from 'drizzle-kit';
 export default {
     schema: './src/lib/db/schema/*',
     out: './src/lib/db/migrations',
-    driver: 'libsql',
+    driver: 'turso',
     dbCredentials: {
         url: env.DATABASE_URL,
+        authToken: env.DATABASE_AUTH_TOKEN,
     },
 } satisfies Config;


### PR DESCRIPTION
The database driver in the configuration file has been changed from 'libsql' to 'turso'. Additionally, an authentication token has been added to the database credentials object, allowing for authentication when connecting to the database.