### PR TITLE
feat: add prettier configuration file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-    "printWidth": 80,
-    "tabWidth": 4,
-    "trailingComma": "all",
-    "singleQuote": true,
-    "plugins": [
-        "@trivago/prettier-plugin-sort-imports"
-    ]
-}

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,0 +1,12 @@
+const config = {
+  printWidth: 80,
+  tabWidth: 4,
+  trailingComma: 'all',
+  singleQuote: true,
+  plugins: [
+    'prettier-plugin-tailwindcss',
+    '@trivago/prettier-plugin-sort-imports',
+  ],
+};
+
+export default config;


### PR DESCRIPTION
The prettier configuration file has been added to the project. It includes the following settings:
- printWidth: 80
- tabWidth: 4
- trailingComma: 'all'
- singleQuote: true
- plugins: 'prettier-plugin-tailwindcss', '@trivago/prettier-plugin-sort-imports'