### PR TITLE
feat: add Artist interface to define the structure of an artist object

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -91,6 +91,19 @@ export interface Item {
     uri: string;
 }
 
+export interface Artist {
+    external_urls: ExternalUrls;
+    followers: Followers;
+    genres: string[];
+    href: string;
+    id: string;
+    images: Image[];
+    name: string;
+    popularity: number;
+    type: string;
+    uri: string;
+}
+
 export interface ExternalUrls {
     spotify: string;
 }


### PR DESCRIPTION
The Artist interface includes properties such as external_urls, followers, genres, href, id, images, name, popularity, type, and uri. This interface is used to represent an artist object in the application.